### PR TITLE
Add templates folder to the build directory

### DIFF
--- a/bin/create-beacon-reader-app.ts
+++ b/bin/create-beacon-reader-app.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { createCli } from '../src/cli';
+
+createCli();

--- a/package.json
+++ b/package.json
@@ -8,18 +8,19 @@
     "url": "git+https://github.com/api3dao/services.git"
   },
   "private": false,
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "files": [
     "dist"
   ],
   "bin": {
-    "create-beacon-reader-app": "./dist/cli/index.js"
+    "create-beacon-reader-app": "./dist/bin/create-beacon-reader-app.js"
   },
   "scripts": {
-    "build": "yarn run clean && yarn run tsc:build",
+    "build": "yarn run clean && yarn run tsc:build && yarn copy-files",
     "clean": "rimraf -rf ./dist *.tgz",
-    "cli": "ts-node src/cli/index.ts",
+    "cli": "ts-node bin/create-beacon-reader-app.ts",
+    "copy-files": "cp -r templates dist",
     "eth-node": "hardhat node",
     "lint:eslint": "eslint . --ext .js,.ts",
     "lint": "yarn run prettier:check && yarn run lint:eslint",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,1 @@
-#!/usr/bin/env node
-import { createCli } from './cli';
-
-createCli();
+export * from './cli';

--- a/test/__snapshots__/e2e.test.ts.snap
+++ b/test/__snapshots__/e2e.test.ts.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Beacon reader CLI shows help 1`] = `
-"index.js
+"create-beacon-reader-app.js
 
 Create a project skeleton for an application that reads a value from beacon
 
 Commands:
-  index.js                           Create a project skeleton for an application that reads a value from beacon
-                                                                                                               [default]
-  index.js show-available-templates  Show the list of available template options
+  create-beacon-reader-app.js                           Create a project skeleton for an application that reads a value
+                                                        from beacon                                            [default]
+  create-beacon-reader-app.js show-available-templates  Show the list of available template options
 
 Options:
       --version   Show version number                                                                          [boolean]
@@ -19,8 +19,8 @@ Options:
                   options.                                                                                      [string]
 
 Examples:
-  index.js                                                      Run the interactive version of the CLI
-  index.js --path=\\".\\"                                           Create the project in the current directory
-  index.js --path=\\"my-app\\"                                      Create the project inside the \\"my-app\\" directory
+  create-beacon-reader-app.js                                   Run the interactive version of the CLI
+  create-beacon-reader-app.js --path=\\".\\"                        Create the project in the current directory
+  create-beacon-reader-app.js --path=\\"my-app\\"                   Create the project inside the \\"my-app\\" directory
   --template=\\"javascript-ethers-hardhat\\""
 `;

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import { createTmpDir } from './utils';
 import { getAvailableTemplates } from '../src/cli/cli';
 
-const CLI_EXECUTABLE = `${__dirname}/../dist/cli/index.js`;
+const CLI_EXECUTABLE = `${__dirname}/../dist/bin/create-beacon-reader-app.js`;
 // Turning this flag to 'true' will print each command before executing it
 // It might be useful to turn on, while debugging particular test.
 const DEBUG_COMMANDS = false;
@@ -80,6 +80,7 @@ describe('Beacon reader CLI', () => {
         const tmpDir = createTmpDir();
 
         // 1. Create a repository based on the current template name
+        if (DEBUG_COMMANDS) console.info(`Beacon project location: ${tmpDir}`);
         execCommand('', ['--path', tmpDir], ['--template', templateName]);
 
         // 2. Change the current working directory to the newly created project folder

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src"],
+  "include": ["bin", "src"],
   "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "baseUrl": "./",
     "outDir": "./dist"
   },
-  "include": ["src", "test"],
+  "include": ["bin", "src", "test"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
After testing the deployed services CLI on npx I found out that the CLI doesn't work.
@amarthadan then told me that I can verify the `npx` locally as well (It didn't cross my mind and I only verified the publishing).

Anyway, I've tested this locally using verdaccio now and it works.