### PR TITLE
Add beacon filename sanitiser function

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -21,11 +21,13 @@
       }
     },
     {
-      "files": "templates/**/*.sol",
+      "files": ["templates/**/*.sol", "contracts/*.sol"],
       "options": {
         "compiler": "0.8.9",
+        "printWidth": 80,
         "tabWidth": 4,
         "useTabs": false,
+        "singleQuote": false,
         "bracketSpacing": false,
         "explicitTypes": "always"
       }

--- a/contracts/IRrpBeaconServer.sol
+++ b/contracts/IRrpBeaconServer.sol
@@ -1,2 +1,2 @@
 // SPDX-License-Identifier: MIT
-import '@api3/airnode-protocol/contracts/rrp/requesters/interfaces/IRrpBeaconServer.sol';
+import "@api3/airnode-protocol/contracts/rrp/requesters/interfaces/IRrpBeaconServer.sol";

--- a/contracts/IRrpBeaconServer.sol
+++ b/contracts/IRrpBeaconServer.sol
@@ -1,2 +1,2 @@
 // SPDX-License-Identifier: MIT
-import "@api3/airnode-protocol/contracts/rrp/requesters/interfaces/IRrpBeaconServer.sol";
+import '@api3/airnode-protocol/contracts/rrp/requesters/interfaces/IRrpBeaconServer.sol';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import _chainsDeploymentInfo from '@api3dao/operations/data/chains.json';
 import { ethers } from 'ethers';
-import { goSync, isGoSuccess } from './utils';
+import { goSync, isGoSuccess, sanitiseFilename } from './utils';
 
 interface ChainInfo {
   AirnodeRrp: string;
@@ -30,7 +30,9 @@ export function getServiceData(apiName: string, beaconName: string, chain: strin
     throw new Error(`Deployment file for ${chain} not found`);
   }
 
-  const goBeaconData = goSync(() => require(`@api3dao/operations/data/apis/${apiName}/beacons/${beaconName}`));
+  const goBeaconData = goSync(() =>
+    require(`@api3dao/operations/data/apis/${apiName}/beacons/${sanitiseFilename(beaconName)}.json`)
+  );
   if (!isGoSuccess(goBeaconData)) throw new Error(`Service data does not exist.`);
   const beaconData = goBeaconData.data;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,21 @@ export type GoResult<T, E = Error> = GoResultSuccess<T> | GoResultError<E>;
 export const GO_ERROR_INDEX = 0;
 export const GO_RESULT_INDEX = 1;
 
+export const sanitiseFilename = (filename: string) => {
+  const illegalRe = /[\/?<>\\:*|"]/g;
+  // eslint-disable-next-line no-control-regex
+  const controlRe = /[\x00-\x1f\x80-\x9f]/g;
+  const reservedRe = /^\.+$/;
+  const windowsReservedRe = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
+
+  return filename
+    .replace(illegalRe, '_')
+    .replace(controlRe, '_')
+    .replace(reservedRe, '_')
+    .replace(windowsReservedRe, '_')
+    .toLocaleLowerCase();
+};
+
 export const successFn = <T>(value: T): GoResultSuccess<T> => {
   const result: any = [null, value];
   // eslint-disable-next-line functional/immutable-data


### PR DESCRIPTION
This PR adds the filename sanitise function used in the operations repository so that if a user enters a documentation-based beacon name it will resolve to the correct file in the operations repository.

I have tested that this works with eg. "AAVE/USD".

References issue #17 