### PR TITLE
Use pinned version of the operations repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14'
-          cache: 'yarn'
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Lint
@@ -43,12 +42,11 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14'
-          cache: 'yarn'
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Build
         run: yarn build
-      - name: Run hardhat node on backround
+      - name: Run hardhat node in the background
         run: yarn eth-node &
       - name: Test
         run: yarn test

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@api3/airnode-protocol": "0.3.1",
-    "@api3dao/operations": "api3dao/operations",
+    "@api3dao/operations": "api3dao/operations#v0.1",
     "@api3dao/utility-contracts": "api3dao/utility-contracts",
     "chalk": "^4.1.2",
     "ethers": "^5.5.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,8 +33,14 @@ export function getServiceData(apiName: string, beaconName: string, chain: strin
   const goBeaconData = goSync(() =>
     require(`@api3dao/operations/data/apis/${apiName}/beacons/${sanitiseFilename(beaconName)}.json`)
   );
-  if (!isGoSuccess(goBeaconData)) throw new Error(`Service data does not exist.`);
+  if (!isGoSuccess(goBeaconData)) throw new Error(`Beacon service data does not exist.`);
   const beaconData = goBeaconData.data;
+
+  const goTemplateData = goSync(() =>
+    require(`@api3dao/operations/data/apis/${apiName}/templates/${sanitiseFilename(beaconName)}.json`)
+  );
+  if (!isGoSuccess(goTemplateData)) throw new Error(`Template service data does not exist.`);
+  const templateData = goTemplateData.data;
 
   return {
     contracts: {
@@ -43,7 +49,7 @@ export function getServiceData(apiName: string, beaconName: string, chain: strin
     beacon: {
       beaconId: beaconData['beaconId'],
       templateId: beaconData['templateId'],
-      parameters: beaconData['decodedParameters'],
+      parameters: templateData['decodedParameters'],
     },
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,9 @@
   dependencies:
     ethers "^5.4.4"
 
-"@api3dao/operations@api3dao/operations":
+"@api3dao/operations@api3dao/operations#v0.1":
   version "1.0.0"
-  resolved "https://codeload.github.com/api3dao/operations/tar.gz/29e04eb50ca94162fec255732b18fec4ba28551e"
+  resolved "https://codeload.github.com/api3dao/operations/tar.gz/83a119d9ba14a84e8d4d9f31a5e3f0e976ef11c8"
   dependencies:
     "@types/prompts" "^2.0.14"
     ethers "^5.5.2"


### PR DESCRIPTION
This makes services use a tagged version of the operations repository - the repository state that it currently uses, so that when we update the operations repository it won't break anything here.